### PR TITLE
Change crates version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ anyhow = "1.0"
 home = "0.5"
 structopt = "0.3"
 serde_json = "1.0"
-skim = "*"
+skim = "0.9"
 toml = "0.5"
 
 [dependencies.serde]


### PR DESCRIPTION
crate.io prohibits the use of wildcards in versions